### PR TITLE
[Fix] Change waitAfterNewBlock type to boolean

### DIFF
--- a/src/xswd.ts
+++ b/src/xswd.ts
@@ -431,7 +431,7 @@ export class Api {
         }
       );
     },
-    async GetSC(params: DEROGetSC, waitAfterNewBlock?: true) {
+    async GetSC(params: DEROGetSC, waitAfterNewBlock?: boolean) {
       if (waitAfterNewBlock) {
         debug("waiting for new block");
         this._api.subscribe({ event: "new_topoheight" }, "auto");


### PR DESCRIPTION
The function originally only allows the value of waitAfterNewBlock to be true, making it impossible to update the value of the SC when a new callback of the new_topoheight happens.

This PR changes the type of the parameter waitAfterNewBlock from true to boolean.
